### PR TITLE
Add SOTIO Global Site Strategy Framework page

### DIFF
--- a/SOTIO-Global-Site-Strategy-Framework.html
+++ b/SOTIO-Global-Site-Strategy-Framework.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>A First-in-Human Readiness Playbook for SOTIO | Tengu C. Muna</title>
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Google Fonts: Inter -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Chart.js for interactive charts -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        /* Custom styles to use the Inter font */
+        body {
+            font-family: 'Inter', sans-serif;
+            scroll-behavior: smooth;
+        }
+        /* Style for the header gradient */
+        .gradient-header {
+            background: linear-gradient(90deg, #064e3b 0%, #0d9488 100%); /* SOTIO-themed gradient */
+        }
+    </style>
+</head>
+<body class="bg-slate-50 text-slate-800">
+
+    <!-- Header Section -->
+    <header class="gradient-header text-white shadow-lg">
+        <div class="max-w-5xl mx-auto px-6 sm:px-8 py-16 md:py-20 text-center">
+            <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight">A First-in-Human Readiness Playbook for SOTIO’s ADC Pipeline</h1>
+            <p class="mt-4 text-lg md:text-xl text-teal-100">A Consulting Proposal by Tengu C. Muna</p>
+        </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="max-w-5xl mx-auto p-6 sm:p-8">
+        
+        <!-- At a Glance Section -->
+        <section id="at-a-glance" class="mb-12">
+             <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
+                <div class="bg-white p-4 rounded-xl shadow-md border border-slate-100">
+                    <p class="text-2xl font-bold text-teal-800">ADC & Cell Therapy</p>
+                    <p class="text-xs text-slate-600 font-medium uppercase tracking-wider">Early-Phase Expertise</p>
+                </div>
+                <div class="bg-white p-4 rounded-xl shadow-md border border-slate-100">
+                    <p class="text-2xl font-bold text-teal-800">Global Phase I/II</p>
+                    <p class="text-xs text-slate-600 font-medium uppercase tracking-wider">Trial Acceleration</p>
+                </div>
+                <div class="bg-white p-4 rounded-xl shadow-md border border-slate-100">
+                    <p class="text-2xl font-bold text-teal-800">EUCTR / IVDR</p>
+                    <p class="text-xs text-slate-600 font-medium uppercase tracking-wider">Regulatory Ready</p>
+                </div>
+                <div class="bg-white p-4 rounded-xl shadow-md border border-slate-100">
+                    <p class="text-2xl font-bold text-teal-800">Inspection</p>
+                    <p class="text-xs text-slate-600 font-medium uppercase tracking-wider">Proven Success (FDA/MHRA)</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Strategic Challenge Section -->
+        <section id="challenge" class="bg-white p-8 rounded-2xl shadow-lg border border-slate-100 mb-12">
+            <h2 class="text-3xl font-bold text-slate-900 mb-4">The Strategic Challenge for SOTIO 🎯</h2>
+            <p class="mb-8 text-slate-600 leading-relaxed">As SOTIO prepares to advance its innovative Antibody-Drug Conjugate (ADC) pipeline into First-in-Human (FIH) trials, the operational strategy for this transition is critical. Moving a novel ADC from preclinical to a global Phase 1 study presents a unique set of high-stakes challenges:</p>
+            <div class="grid md:grid-cols-3 gap-6">
+                <div class="bg-slate-50 p-6 rounded-xl border">
+                    <h3 class="font-bold text-lg text-slate-800">1. Accelerating Timelines</h3>
+                    <p class="text-sm text-slate-600 mt-3">Ensuring rapid site activation and enrollment across the US & EU to achieve timely dose-escalation data.</p>
+                </div>
+                <div class="bg-slate-50 p-6 rounded-xl border">
+                    <h3 class="font-bold text-lg text-slate-800">2. Navigating Complex Safety</h3>
+                    <p class="text-sm text-slate-600 mt-3">Training sites to proactively monitor and manage unique ADC toxicities (e.g., on-target/off-tumor effects).</p>
+                </div>
+                <div class="bg-slate-50 p-6 rounded-xl border">
+                    <h3 class="font-bold text-lg text-slate-800">3. Harmonizing Regulations</h3>
+                    <p class="text-sm text-slate-600 mt-3">Seamlessly navigating FDA rules alongside stringent EUCTR and IVDR requirements to ensure data integrity.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Monitoring Strategy Section -->
+        <section id="strategy">
+            <h2 class="text-3xl font-bold text-slate-900 mb-8 text-center">The FIH Readiness Playbook: Key Strategies</h2>
+            <div class="space-y-12">
+                
+                <!-- Pillar 1 -->
+                <div class="bg-white p-8 rounded-2xl shadow-lg border border-slate-100">
+                    <div class="flex flex-col md:flex-row items-center gap-8">
+                        <div class="flex-shrink-0 flex items-center justify-center w-24 h-24 bg-blue-100 rounded-full">
+                            <svg class="w-12 h-12 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2h8a2 2 0 002-2v-1a2 2 0 012-2h1.945M7.884 11H16.116M12 17.25v-6.5M4.5 12.75l-1.5 1.5M19.5 12.75l1.5 1.5"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.5v.01M17.25 6.75l.01.01M6.75 6.75l.01.01"></path></svg>
+                        </div>
+                        <div>
+                            <h3 class="text-2xl font-bold text-slate-900 mb-2">1. Streamlined Global Site Activation 🌍</h3>
+                            <p class="text-slate-600 leading-relaxed">I will accelerate site activation by developing a harmonized US/EU monitoring plan and a specific EUCTR/IVDR compliance module to prevent common start-up delays in Europe.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Pillar 2 -->
+                <div class="bg-white p-8 rounded-2xl shadow-lg border border-slate-100">
+                    <div class="flex flex-col md:flex-row items-center gap-8">
+                        <div class="flex-shrink-0 flex items-center justify-center w-24 h-24 bg-green-100 rounded-full">
+                             <svg class="w-12 h-12 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                        </div>
+                        <div>
+                            <h3 class="text-2xl font-bold text-slate-900 mb-2">2. Specialized ADC Site Empowerment 👩‍🏫</h3>
+                            <p class="text-slate-600 leading-relaxed">I will equip investigative sites with the specialized knowledge they need by designing targeted ADC safety training and conducting "First Patient In" simulation workshops to resolve workflow issues before they happen.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Pillar 3 -->
+                <div class="bg-white p-8 rounded-2xl shadow-lg border border-slate-100">
+                     <div class="flex flex-col md:flex-row items-center gap-8">
+                        <div class="flex-shrink-0 flex items-center justify-center w-24 h-24 bg-purple-100 rounded-full">
+                            <svg class="w-12 h-12 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                        </div>
+                        <div>
+                            <h3 class="text-2xl font-bold text-slate-900 mb-2">3. Proactive Data & Inspection Readiness ✅</h3>
+                            <p class="text-slate-600 leading-relaxed">I will ensure pristine data and a state of continuous inspection readiness by implementing real-time KPI dashboards and building the TMF to "tell a story" for regulators, making inspections a formality, not a fire drill.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Projected Impact Section -->
+        <section id="impact" class="mt-12 bg-white p-8 rounded-2xl shadow-lg border border-slate-100">
+            <h2 class="text-3xl font-bold text-slate-900 mb-4 text-center">Projected Impact of the FIH Readiness Playbook 📈</h2>
+            <p class="text-center text-slate-600 mb-8 max-w-2xl mx-auto">By executing this strategic playbook, SOTIO can anticipate significant improvements in trial efficiency and data quality for its ADC program.</p>
+            <div class="w-full max-w-3xl mx-auto">
+                <canvas id="impactChart"></canvas>
+            </div>
+        </section>
+
+        <!-- Conclusion Section -->
+        <section id="conclusion" class="mt-12 text-center bg-teal-800 text-white p-12 rounded-2xl">
+            <h2 class="text-3xl font-bold mb-4">De-Risking SOTIO’s Path to the Clinic</h2>
+            <p class="max-w-3xl mx-auto mb-6">
+                This First-in-Human Readiness Playbook provides a robust, proactive framework to ensure SOTIO’s innovative ADC trials are set up for success. By focusing on harmonized global operations, specialized site empowerment, and continuous inspection readiness, this strategy mitigates common risks, accelerates timelines, and ensures the collection of high-quality data.
+            </p>
+            <p class="font-semibold">This approach will allow SOTIO to confidently and efficiently translate its compelling science into tangible patient benefit.</p>
+            <p class="mt-4 text-2xl font-bold">Tengu C. Muna</p>
+        </section>
+
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-slate-800 text-slate-300 mt-12 text-center">
+        <div class="max-w-5xl mx-auto p-6 text-sm">
+            <p>&copy; 2025 Tengu C. Muna | Consulting Proposal for SOTIO Biotech</p>
+        </div>
+    </footer>
+
+    <script>
+        // Chart.js configuration for the Projected Impact chart
+        const ctx = document.getElementById('impactChart');
+        if (ctx) {
+            new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels: ['Time-to-First-Patient-In', 'Screen Failure Rate', 'Critical Safety Event Delays', 'Inspection Readiness'],
+                    datasets: [{
+                        label: 'Standard FIH Launch (Baseline)',
+                        data: [100, 100, 100, 50], // Baseline 100%, Readiness starts lower
+                        backgroundColor: 'rgba(100, 116, 139, 0.6)', // slate-500
+                        borderColor: 'rgba(100, 116, 139, 1)',
+                        borderWidth: 1
+                    }, {
+                        label: 'With Readiness Playbook (Projected)',
+                        data: [50, 75, 10, 100], // Representing % reduction or improvement
+                        backgroundColor: 'rgba(13, 148, 136, 0.6)', // teal-600
+                        borderColor: 'rgba(13, 148, 136, 1)',
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    plugins: {
+                        legend: {
+                            position: 'top',
+                        },
+                        title: {
+                            display: true,
+                            text: 'Projected KPI Improvement'
+                        },
+                        tooltip: {
+                             callbacks: {
+                                label: function(context) {
+                                    let label = context.dataset.label || '';
+                                    if (label) { label += ': '; }
+                                    let value = context.parsed.y;
+                                    if(context.label === 'Time-to-First-Patient-In' && context.datasetIndex === 1) {
+                                        label += '50% Reduction';
+                                    } else if (context.label === 'Screen Failure Rate' && context.datasetIndex === 1) {
+                                        label += '25% Reduction';
+                                    } else if (context.label === 'Critical Safety Event Delays' && context.datasetIndex === 1) {
+                                        label += 'Near Elimination';
+                                    } else if (context.label === 'Inspection Readiness' && context.datasetIndex === 1) {
+                                        label += '100% (Continuous)';
+                                    } else {
+                                        label += 'Baseline';
+                                    }
+                                    return label;
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            max: 110,
+                            ticks: {
+                                callback: function(value) {
+                                    return value + '%'
+                                }
+                            },
+                            title: {
+                                display: true,
+                                text: 'Relative Performance / Readiness'
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SOTIO Global Site Strategy Framework HTML page showcasing FIH readiness playbook, strategic pillars, and KPI chart

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689239d2ff6483318bcb9d611a1564ef