### PR TITLE
Add BioInvent patient-first strategy case study

### DIFF
--- a/BioInvent-PatientFirst-Strategy.html
+++ b/BioInvent-PatientFirst-Strategy.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Case Study: A New Vision for BioInvent's Clinical Trials</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            display: flex;
+            flex-direction: column;
+            min-height: 100vh;
+        }
+        .container {
+            flex-grow: 1;
+        }
+        .tab-active {
+            border-color: #3b82f6;
+            color: #3b82f6;
+            background-color: #eff6ff;
+        }
+    </style>
+</head>
+<body class="bg-slate-50 text-slate-800">
+
+    <div class="container mx-auto p-4 md:p-8">
+
+        <!-- Header Section -->
+        <header class="text-center mb-8 md:mb-12">
+            <h1 class="text-3xl md:text-5xl font-bold text-blue-600 mb-2">🧬 From Promise to Patient</h1>
+            <p class="text-lg md:text-xl text-slate-600">A New Vision for BioInvent's Clinical Trials</p>
+        </header>
+
+        <!-- Tab Navigation -->
+        <div class="mb-8 border-b border-slate-200">
+            <nav class="flex flex-wrap -mb-px" aria-label="Tabs">
+                <button class="tab-btn tab-active w-full sm:w-auto text-center sm:text-left whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" data-tab="promise">
+                    🚀 The Promise
+                </button>
+                <button class="tab-btn w-full sm:w-auto text-center sm:text-left whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm text-slate-500 hover:text-blue-600 hover:border-blue-300" data-tab="opportunity">
+                    🎯 The Opportunity
+                </button>
+                <button class="tab-btn w-full sm:w-auto text-center sm:text-left whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm text-slate-500 hover:text-blue-600 hover:border-blue-300" data-tab="blueprint">
+                    🗺️ The Blueprint
+                </button>
+                <button class="tab-btn w-full sm:w-auto text-center sm:text-left whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm text-slate-500 hover:text-blue-600 hover:border-blue-300" data-tab="pipeline">
+                    💡 The Pipeline
+                </button>
+
+                <button class="tab-btn w-full sm:w-auto text-center sm:text-left whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm text-slate-500 hover:text-blue-600 hover:border-blue-300" data-tab="partnership">
+                    🌟 The Partnership
+                </button>
+            </nav>
+        </div>
+
+        <!-- Tab Content -->
+        <main id="tab-content">
+            <!-- Promise Tab -->
+            <div id="promise" class="tab-pane">
+                <div class="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-slate-100">
+                    <h2 class="text-2xl font-bold text-blue-700 mb-4">The Promise in Your Pipeline 🚀</h2>
+                    <p class="mb-4 text-slate-600">BioInvent’s science is truly pioneering. In your labs, you are crafting the future of cancer treatment—therapies that don't just fight a disease, but empower a patient's own body to heal. This is more than just medicine; it's a new chapter of hope for people facing the most difficult diagnoses of their lives.</p>
+                    <p class="text-slate-600">But the journey from a brilliant discovery to a life-changing treatment is one of the most challenging in modern medicine. The greatest hurdle we face is not in the science, but in reaching the very people that science is meant for.</p>
+                </div>
+            </div>
+
+            <!-- Opportunity Tab -->
+            <div id="opportunity" class="tab-pane hidden">
+                <div class="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-slate-100">
+                    <h2 class="text-2xl font-bold text-blue-700 mb-6">The Challenge and The Opportunity 🎯</h2>
+                    <div class="space-y-6">
+                        <div class="p-6 rounded-lg bg-blue-50 border border-blue-100">
+                            <h3 class="font-semibold text-lg text-blue-800 mb-2">🔍 The Challenge</h3>
+                            <p class="text-slate-600">Recruiting and retaining diverse patient populations remains a primary obstacle. Oncology trials historically struggle to include underrepresented communities, limiting the generalizability of data. Furthermore, the increasing adoption of decentralized trials (DCTs) requires sophisticated strategies to ensure equitable patient engagement, data integrity, and regulatory compliance across the globe.</p>
+                        </div>
+                        <div class="p-6 rounded-lg bg-green-50 border border-green-100">
+                            <h3 class="font-semibold text-lg text-green-800 mb-3">✅ The Proposed Solution</h3>
+                            <p class="text-slate-600 mb-4">Overcome these hurdles by implementing a multi-faceted strategy centered on:</p>
+                            <ul class="space-y-2 text-slate-700">
+                                <li class="flex items-start"><span class="text-green-500 mr-2 mt-1">✔</span><span><strong class="font-semibold">AI-Driven Patient Recruitment:</strong> Leverage technology to pinpoint eligible patients and build trust.</span></li>
+                                <li class="flex items-start"><span class="text-green-500 mr-2 mt-1">✔</span><span><strong class="font-semibold">Diversity, Equity, and Inclusion (DEI):</strong> Build robust initiatives to ensure trials represent everyone.</span></li>
+                                <li class="flex items-start"><span class="text-green-500 mr-2 mt-1">✔</span><span><strong class="font-semibold">Seamless DCT Integration:</strong> Use technology to reduce the burden on participants.</span></li>
+                            </ul>
+                        </div>
+                        <div class="p-6 rounded-lg bg-indigo-50 border border-indigo-100">
+                            <h3 class="font-semibold text-lg text-indigo-800 mb-3">📈 The Projected Outcome</h3>
+                            <p class="text-slate-600 mb-4">The integration of these strategies will lead to:</p>
+                            <ul class="space-y-2 text-slate-700">
+                                <li class="flex items-start"><span class="text-indigo-500 mr-2 mt-1">✔</span><span>More efficient, inclusive, and patient-centric clinical trials.</span></li>
+                                <li class="flex items-start"><span class="text-indigo-500 mr-2 mt-1">✔</span><span>Accelerated development timelines for key therapies like BI-1206 and BI-1808.</span></li>
+                                <li class="flex items-start"><span class="text-indigo-500 mr-2 mt-1">✔</span><span>More robust, representative data to ensure therapies meet global patient needs.</span></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Blueprint Tab -->
+            <div id="blueprint" class="tab-pane hidden">
+
+                <div class="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-slate-100">
+                    <h2 class="text-2xl font-bold text-blue-700 mb-6">Our Blueprint for Hope: A Patient-First Strategy 🗺️</h2>
+                    <div class="grid md:grid-cols-3 gap-6 text-center">
+                        <div class="p-6 rounded-lg bg-slate-50 border border-slate-200">
+                            <div class="text-4xl mb-3">❤️</div>
+                            <h3 class="font-semibold text-lg text-slate-800 mb-2">AI with a Human Heart</h3>
+                            <p class="text-slate-600 text-sm">Use AI to analyze real-world data to find individual patients, not just statistics, and connect them with the right trials faster.</p>
+                        </div>
+                        <div class="p-6 rounded-lg bg-slate-50 border border-slate-200">
+                            <div class="text-4xl mb-3">🤝</div>
+                            <h3 class="font-semibold text-lg text-slate-800 mb-2">Inclusion as Our Cornerstone</h3>
+                            <p class="text-slate-600 text-sm">Build genuine partnerships with community doctors and organizations to ensure the future of medicine includes everyone.</p>
+                        </div>
+                        <div class="p-6 rounded-lg bg-slate-50 border border-slate-200">
+                            <div class="text-4xl mb-3">🏠</div>
+                            <h3 class="font-semibold text-lg text-slate-800 mb-2">Trials That Come to the Patient</h3>
+                            <p class="text-slate-600 text-sm">Integrate user-friendly tech like eConsent, telemedicine, and wearables to reduce patient burden and improve engagement.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Pipeline Tab -->
+            <div id="pipeline" class="tab-pane hidden">
+                <div class="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-slate-100">
+                    <h2 class="text-2xl font-bold text-blue-700 mb-6">Bringing the Blueprint to Life for Your Pipeline 💡</h2>
+                    <ul class="space-y-4">
+                        <li class="flex items-start space-x-4 p-4 rounded-lg hover:bg-slate-50">
+                            <span class="text-2xl mt-1">🩸</span>
+                            <div>
+                                <h3 class="font-semibold text-slate-800">For BI-1206 & BI-1607 (Blood Cancers & Melanoma)</h3>
+                                <p class="text-slate-600">Use AI to mine hematology-oncology registries. Partner with trusted foundations like the Lymphoma Research Foundation and Melanoma Research Alliance for outreach and provide proactive telehealth support.</p>
+                            </div>
+                        </li>
+                        <li class="flex items-start space-x-4 p-4 rounded-lg hover:bg-slate-50">
+                            <span class="text-2xl mt-1">🫁</span>
+                            <div>
+                                <h3 class="font-semibold text-slate-800">For BI-1808 & BI-1910 (Solid Tumors)</h3>
+                                <p class="text-slate-600">Utilize AI to scan genomic databases for patients with high TNFR2 expression. Launch a community-centric model with oncology networks and ease participation with a DCT model using wearable tech.</p>
+                            </div>
+                        </li>
+                        <li class="flex items-start space-x-4 p-4 rounded-lg hover:bg-slate-50">
+                            <span class="text-2xl mt-1">🦠</span>
+                            <div>
+                                <h3 class="font-semibold text-slate-800">For BT-001 (Oncolytic Virus)</h3>
+                                <p class="text-slate-600">After using AI to find patients meeting complex criteria, create a dedicated nurse navigator program to provide a direct human connection, guide patients, and ensure they feel valued.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Partnership Tab -->
+            <div id="partnership" class="tab-pane hidden">
+                <div class="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-slate-100">
+                    <h2 class="text-2xl font-bold text-blue-700 mb-6">Our Partnership: A Shared Mission 🌟</h2>
+                    <p class="text-slate-600 mb-6">This is more than a consulting proposal; it's a commitment to your mission. My role is not just to advise, but to embed myself with your team and build a clinical operations engine that is as innovative and compassionate as your science.</p>
+                    <h3 class="font-semibold text-lg text-slate-800 mb-4">My promise is to be your partner in:</h3>
+                    <div class="space-y-4">
+                        <div class="flex items-center space-x-3 p-4 bg-blue-50 rounded-lg">
+                            <span class="text-2xl">⚙️</span>
+                            <p class="text-blue-800"><strong class="font-semibold">Translating Vision into Action:</strong> I will bring the hands-on, global experience needed to turn these strategies into a reality.</p>
+                        </div>
+                        <div class="flex items-center space-x-3 p-4 bg-blue-50 rounded-lg">
+                            <span class="text-2xl">💬</span>
+                            <p class="text-blue-800"><strong class="font-semibold">Championing the Patient Voice:</strong> I will ensure the voice of the patient is at the center of every decision we make.</p>
+                        </div>
+                        <div class="flex items-center space-x-3 p-4 bg-blue-50 rounded-lg">
+                            <span class="text-2xl">⚡</span>
+                            <p class="text-blue-800"><strong class="font-semibold">Accelerating Your Impact:</strong> My goal is to help you move your therapies from promise to patient, faster. Your success is a victory for every person and family that will benefit from your work.</p>
+                        </div>
+                    </div>
+                    <p class="mt-8 text-center text-lg font-medium text-slate-700">Together, we can build a new paradigm for clinical trials—one that closes the gap between groundbreaking science and the people who need it most. 🌍</p>
+                </div>
+            </div>
+        </main>
+
+    </div>
+
+    <!-- Footer Section -->
+    <footer class="text-center p-4 md:p-6 bg-slate-100 border-t border-slate-200">
+        <p class="text-sm font-semibold text-slate-700">From Science to Patient: A Strategic Approach to Scaling BioInvent's Immuno-Oncology Pipeline</p>
+        <p class="text-xs text-slate-500 mt-1">A Case Study by Tengu Muna</p>
+        <p class="text-xs text-slate-500 mt-2">© 2025 All Rights Reserved.</p>
+    </footer>
+
+    <script>
+        // JavaScript for tab functionality
+        const tabButtons = document.querySelectorAll('.tab-btn');
+        const tabPanes = document.querySelectorAll('.tab-pane');
+
+        tabButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                // Deactivate all buttons
+                tabButtons.forEach(btn => {
+                    btn.classList.remove('tab-active');
+                    btn.classList.add('text-slate-500', 'hover:text-blue-600', 'hover:border-blue-300');
+                });
+
+                // Activate the clicked button
+                button.classList.add('tab-active');
+                button.classList.remove('text-slate-500', 'hover:text-blue-600', 'hover:border-blue-300');
+
+                // Hide all panes
+                tabPanes.forEach(pane => {
+                    pane.classList.add('hidden');
+                });
+
+                // Show the corresponding pane
+                const tabId = button.dataset.tab;
+                const activePane = document.getElementById(tabId);
+                if (activePane) {
+                    activePane.classList.remove('hidden');
+                }
+            });
+        });
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add BioInvent-PatientFirst-Strategy case study HTML page with interactive tabs for promise, opportunity, blueprint, pipeline, and partnership sections.

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e44aa9c1c83319fb1ec8207e771c0